### PR TITLE
Add support for function as `wait` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,7 @@ var saveCycles = debounce(expensiveOperation, 100, {leading: true})
 ## Api
 `debounce(func, [wait=0], [{leading: true|false})`
 
-Returns a debounced version of `func` that delays invoking until after `wait` milliseconds. Set `leading: true` if you 
-want to call `func` immediately and use the value from the first call for all subsequent promises
+Returns a debounced version of `func` that delays invoking until after `wait` milliseconds. Set `leading: true` if you
+want to call `func` immediately and use the value from the first call for all subsequent promises.
+
+Supports passing a function as the `wait` parameter, which provides a way to lazily or dynamically define a wait timeout.

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
       }
     }
     clearTimeout(timer)
-    timer = setTimeout(run.bind(null, nextArgs, resolve, reject), wait)
+    timer = setTimeout(run.bind(null, nextArgs, resolve, reject), getWait(wait))
     return pending
   }
 
@@ -33,5 +33,12 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
     reject = null
     pending = null
     timer = null
+  }
+
+  function getWait(_wait) {
+    if (typeof _wait === 'function') {
+      return _wait()
+    }
+    return _wait
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,17 @@ test('waits until the wait time has passed', async t => {
   t.equal(callCount, 1)
 })
 
+test('supports passing function as wait parameter', async t => {
+  let callCount = 0
+  const debounced = debounce(async () => callCount++, () => 10)
+  debounced()
+  debounced()
+  debounced()
+  t.equal(callCount, 0)
+  await sleep(20)
+  t.equal(callCount, 1)
+})
+
 test('calls the given function again if wait time has passed', async t => {
   let callCount = 0
   const debounced = debounce(async () => callCount++, 10)


### PR DESCRIPTION
In order to satisfy a use case for our app, we need the ability to
lazily evaulate the wait duration of the debounce timeout. Accomplish
this by allowing `wait` to be a function.

@bjoerge would you accept this change?