### PR TITLE
Fixes second callback after timeout when leading: true

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
   let timer
   return function (...args) {
     nextArgs = args
+    let onTimeout = run.bind(this, nextArgs, resolve, reject)
     if (!pending) {
       if (leading) {
         pending = fn.apply(this, nextArgs)
+        onTimeout = clear
       } else {
         pending = new Promise((_resolve, _reject) => {
           resolve = _resolve
@@ -18,7 +20,7 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
       }
     }
     clearTimeout(timer)
-    timer = setTimeout(run.bind(this, nextArgs, resolve, reject), getWait(wait))
+    timer = setTimeout(onTimeout, getWait(wait))
     return pending
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,22 @@ test('do not call the given function repeatedly', async t => {
   t.equal(callCount, 1)
 })
 
+test('does not call the given function again after the timeout when leading=true if executed only once', async t => {
+  let callCount = 0
+  const debounced = debounce(async () => callCount++, 100, {leading: true})
+  await debounced()
+  await sleep(200)
+  t.equal(callCount, 1)
+})
+
+test('calls the given function again after the timeout when leading=true if executed multiple times', async t => {
+  let callCount = 0
+  const debounced = debounce(async () => callCount++, 100, {leading: true})
+  await* [1, 2, 3, 4].map(debounced)
+  await sleep(200)
+  t.equal(callCount, 2)
+})
+
 test('waits until the wait time has passed', async t => {
   let callCount = 0
   const debounced = debounce(async () => callCount++, 10)


### PR DESCRIPTION
I noticed while working on the [context pull request](https://github.com/bjoerge/debounce-promise/pull/3) test cases that my debounced function was actually getting called twice when `leading: true`. This was not caught in the current tests because the promise resolves immediately  before the debounce timeout has fully completed.

This pull request uses `clear` for the timeout when `leading: true` rather than `run`. The latter was calling the function a second time after the timeout elapsed.