### PR TITLE
Maintain "this" context when calling the debounced function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,19 +6,21 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
   let reject
   let timer
   return function (...args) {
+    let onTimeout = clear
     nextArgs = args
-    if (!pending) {
-      if (leading) {
-        pending = fn(...nextArgs)
-      } else {
+    if (!leading) {
+      if (!pending) {
         pending = new Promise((_resolve, _reject) => {
           resolve = _resolve
           reject = _reject
         })
       }
+      onTimeout = run.bind(null, nextArgs, resolve, reject)
+    } else if (!pending) {
+      pending = fn(...nextArgs)
     }
     clearTimeout(timer)
-    timer = setTimeout(run.bind(null, nextArgs, resolve, reject), getWait(wait))
+    timer = setTimeout(onTimeout, getWait(wait))
     return pending
   }
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
           reject = _reject
         })
       }
-      onTimeout = run.bind(null, nextArgs, resolve, reject)
+      onTimeout = run.bind(this, nextArgs, resolve, reject)
     } else if (!pending) {
-      pending = fn(...nextArgs)
+      pending = fn.apply(this, nextArgs)
     }
     clearTimeout(timer)
     timer = setTimeout(onTimeout, getWait(wait))
@@ -25,7 +25,7 @@ export default function debounce(fn, wait = 0, {leading = false} = {}) {
   }
 
   function run(_nextArgs, _resolve, _reject) {
-    fn(..._nextArgs).then(_resolve, _reject)
+    fn.apply(this, _nextArgs).then(_resolve, _reject)
     clear()
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,14 @@ test('do not call the given function repeatedly', async t => {
   t.equal(callCount, 1)
 })
 
+test('do not call the given function again after the timeout when leading=true', async t => {
+  let callCount = 0
+  const debounced = debounce(async () => callCount++, 100, {leading: true})
+  await* [1, 2, 3, 4].map(debounced)
+  await sleep(200)
+  t.equal(callCount, 1)
+})
+
 test('waits until the wait time has passed', async t => {
   let callCount = 0
   const debounced = debounce(async () => callCount++, 10)

--- a/test/index.js
+++ b/test/index.js
@@ -71,3 +71,30 @@ test('calls the given function again if wait time has passed', async t => {
   await sleep(20)
   t.equal(callCount, 2)
 })
+
+test('maintains the context of the original function', async t => {
+  const context = {
+    foo: 1,
+    debounced: debounce(async function () {
+      await this.foo++
+    }, 10)
+  }
+
+  context.debounced()
+
+  await sleep(20)
+  t.equal(context.foo, 2)
+})
+
+test('maintains the context of the original function when leading=true', async t => {
+  const context = {
+    foo: 1,
+    debounced: debounce(async function () {
+      await this.foo++
+    }, 10, {leading: true})
+  }
+
+  await context.debounced()
+
+  t.equal(context.foo, 2)
+})


### PR DESCRIPTION
When attempting to use debounce-promise to decorate an ES6 class method I noticed that the context in which the debounced wrapper is called does not get passed along to the original function. Instead, it was always called with an `undefined` context. 

ESLint shows some warnings due to using `Function.prototype.apply` rather than `Reflect.apply`, but since the latter requires a babel polyfill I opted for the former.

This pull request is based on and should be merged after #2 