### PR TITLE
Fix/expensive promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,19 @@ module.exports = function debounce (fn, wait = 0, {leading = false, accumulate =
 
   function callOriginal (args, deferred) {
     const returnValue = accumulate ? fn.call(this, args) : fn.apply(this, args[args.length - 1])
+    if (!leading) {
+      clear()
+    }
     returnValue.then(v => {
       deferred.resolve(v)
-      clear()
+      if (leading) {
+        clear()
+      }
     }, err => {
       deferred.reject(err)
-      clear()
+      if (leading) {
+        clear()
+      }
     })
   }
 


### PR DESCRIPTION
Hello,

I have some problems when using the library with expensive Promises (they each take around 2 seconds).

If the cold debounced function is called with a second Promise is called and the first one is not finished, they share the same defer object. Here is a solution that seems to work for me, with a new test showing my problem.

If I actually do not correctly use the library and you think there is no bug, do not hesitate to tell me so.

Thank you!