### PR TITLE
Clarify accumulate: true example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ var saveCycles = debounce(expensiveOperation, 100, {leading: true});
 ```js
 var debounce = require('debounce-promise')
 
-function squareValues (values) {
-  return Promise.all(values.map(val => val * val))
+function squareValues (argTuples) {
+  return Promise.all(argTuples.map(args => args[0] * args[0]))
 }
 
 var square = debounce(squareValues, 100, {accumulate: true});


### PR DESCRIPTION
The existing `squareValues` example is misleading in the sense that it makes a reader believe that `values` is (naturally) an array of passed values. However, `values` in the example is actually an array of arguments arrays:

```js
function squareValues (values) {
  console.log(values) // [ [ 1 ], [ 2 ], [ 3 ], [ 4 ] ]
  return Promise.all(values.map(val => val * val))
}
```

Coincidentally, multiplying arrays `[ 2 ] * [ 2 ]` gives 4 in Javascript, which obscures the fact that values consists of arrays rather than values. But this conversion is not going to take place in most other circumstances. For instance, if you return `val + val` instead of `val * val` in your example, the debounced promise will resolve to `11 22 33 44` instead of `1 2 4 8`.

The PR makes it more obvious to infer the actual API from the example:

```js
function squareValues (argTuples) {
  return Promise.all(argTuples.map(args => args[0] * args[0]))
}
```

Another options would be to use arguments destructuring:

```js
function squareValues (argTuples) {
  return Promise.all(argTuples.map(({0: value}) => value * value))
}
```

but I think it's even harder to comprehend.