### PR TITLE
Fix nested debounced calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function debounce (fn, wait = 0, options = {}) {
   }
 
   function flush () {
-    const thisDeferred = deferred
+    const thisDeferred = deferred ? Object.assign(deferred) : null;
     clearTimeout(timer)
 
     Promise.resolve(


### PR DESCRIPTION
Recently came up with 'TypeError: Cannot read property 'resolve' of null at flush' in nested debounced call.

```js
const debounced = debouncePromise(
    () => shouldIterate
        ? callIterate()
        : Promise.resolve(),
    1500,
    {leading: false},
)

let shouldIterate = true;
const iterate = () => {
    let a = 0;
    for (let i = 0; i < 10000; i++) {
        a++;
    }
    return a;
};
const callIterate = () => {
    debounced();
    iterate();
    shouldIterate = false;
};

debounced();
```